### PR TITLE
Rename section IDs and refine typography

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,7 +169,7 @@ h6 {
     font-family: "Google Sans Flex", sans-serif;
     font-weight: 450;
     line-height: 1.35;
-    letter-spacing: -2%;
+    letter-spacing: -0.02em;
 }
 
 h3 {
@@ -217,12 +217,12 @@ section {
 }
 
 #hero,
-#about,
-#work,
+#about-me,
+#experience,
 #services,
 #fun,
 #projects,
-#contact {
+#contact-me {
     scroll-margin-top: clamp(4.5rem, 9vh, 6.75rem);
 }
 
@@ -541,7 +541,11 @@ img.section-shell__shot {
     min-height: 0;
     box-sizing: border-box;
     color: var(--base-paper);
-    overflow-wrap: anywhere;
+    /* Prefer whole words; avoid “UI-” style mid-token breaks */
+    overflow-wrap: break-word;
+    word-break: normal;
+    hyphens: none;
+    -webkit-hyphens: none;
 }
 
 .hero-headline .software-word,
@@ -553,6 +557,10 @@ img.section-shell__shot {
         var(--hero-fs-vw, 5.5) * (0.58vmin + 0.42vw) + var(--hero-fs-add)
     );
     line-height: 1.35;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: normal;
+    hyphens: none;
 }
 
 /* Scramble wraps each glyph in <span> — give glyphs room so lines don’t crash */
@@ -817,7 +825,7 @@ img.section-shell__shot {
 
 .menu a .char,
 .menu-col h3,
-.menucol h6,
+.menu-col h6,
 .menu-col p {
     will-change: transform, opacity;
 }

--- a/index.html
+++ b/index.html
@@ -93,12 +93,12 @@
           </div>
 
           <div class="menu-col menu-col-links">
-            <a href="#work">work</a>
+            <a href="#experience">work</a>
             <a href="#services">services</a>
-            <a href="#about">about</a>
+            <a href="#about-me">about</a>
             <a href="#fun">fun</a>
             <a href="#projects">projects</a>
-            <a href="#contact">contact</a>
+            <a href="#contact-me">contact</a>
           </div>
         </div>
       </div>
@@ -109,7 +109,7 @@
 
   <section id="hero" class="hero">
     <div class="hero-title">
-      <h2 class="hero-headline" aria-label="">
+      <h2 class="hero-headline" aria-label="Software Engineer">
         <span class="software-word"></span>
         <span class="engineer-word"></span>
       </h2>
@@ -152,7 +152,7 @@
     </div> -->
   </section>
   
-  <section id="about" class="about" aria-labelledby="about-heading">
+  <section id="about-me" class="about" aria-labelledby="about-heading">
     <header class="about-header">
       <h2 id="about-heading" class="about-title">
         About
@@ -181,7 +181,7 @@
     <hr class="about-rule" aria-hidden="true" />
   </section>
 
-  <section id="work" class="work" aria-labelledby="work-heading">
+  <section id="experience" class="work" aria-labelledby="work-heading">
     <header class="work-header">
       <h2 id="work-heading" class="work-title">
         Where I&rsquo;ve worked
@@ -303,7 +303,7 @@
     <p class="section-shell__lede">Highlighted work — more soon.</p>
   </section>
 
-  <section id="contact" class="section-shell" aria-labelledby="contact-heading">
+  <section id="contact-me" class="section-shell" aria-labelledby="contact-heading">
     <h2 id="contact-heading" class="section-shell__title">Get in touch</h2>
     <div class="section-shell__prose">
       <p>

--- a/js/script.js
+++ b/js/script.js
@@ -311,12 +311,12 @@ const closeMenu = (afterClose) => {
 
   const SECTION_LABELS = {
     hero: 'Gerlin',
-    about: 'About',
-    work: 'Work',
+    'about-me': 'About',
+    experience: 'Work',
     services: 'Services',
     fun: 'Fun',
     projects: 'Projects',
-    contact: 'Contact',
+    'contact-me': 'Contact',
   };
 
   const sections = [
@@ -331,12 +331,12 @@ const closeMenu = (afterClose) => {
    */
   const SECTION_SENTINEL_SELECTOR = {
     hero: '#hero .hero-headline',
-    about: '#about-heading',
-    work: '#work-heading',
+    'about-me': '#about-heading',
+    experience: '#work-heading',
     services: '#services-heading',
     fun: '#fun-heading',
     projects: '#projects-heading',
-    contact: '#contact-heading',
+    'contact-me': '#contact-heading',
   };
 
   function sentinelFor(sectionEl) {


### PR DESCRIPTION
Rename section anchors from about, work, contact to about-me, experience, contact-me across HTML, CSS and JS so nav links and sentinels match. Adjust typography and word-wrapping: change letter-spacing to -0.02em, prefer break-word/normal word-break and disable hyphenation to avoid mid-token breaks, add max-width for headline glyph wrapping. Fix CSS selector typo (.menucol → .menu-col) and add an aria-label to the hero headline for clarity and accessibility.